### PR TITLE
Order latest version by NuGet version

### DIFF
--- a/src/Dotnet.Deps.Core/NuGet/ILatestVersionProvider.cs
+++ b/src/Dotnet.Deps.Core/NuGet/ILatestVersionProvider.cs
@@ -87,11 +87,11 @@ namespace Dotnet.Deps.Core.NuGet
 
                 if (preRelease)
                 {
-                    latestVersionInRepository = allVersions.LastOrDefault();
+                    latestVersionInRepository = allVersions.OrderBy(nv => nv).LastOrDefault();
                 }
                 else
                 {
-                    latestVersionInRepository = allVersions.Where(v => !v.IsPrerelease).LastOrDefault();
+                    latestVersionInRepository = allVersions.Where(v => !v.IsPrerelease).OrderBy(nv => nv).LastOrDefault();
                 }
 
                 if (latestVersionInRepository != null)

--- a/src/Dotnet.Deps/Dotnet.Deps.csproj
+++ b/src/Dotnet.Deps/Dotnet.Deps.csproj
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/seesharper/dotnet-deps.git</RepositoryUrl>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes a bug where assumed the correct ordering when getting the latest version of a package.